### PR TITLE
Add: auto exercise generator, grader, CLI and sample reverse_string e…

### DIFF
--- a/exercises/auto_grader/README.md
+++ b/exercises/auto_grader/README.md
@@ -1,0 +1,8 @@
+# Auto Grader
+
+This folder contains a small exercise generator and auto-grader to scaffold exercises and run tests locally.
+
+## Quickstart
+1. Scaffold a new exercise:
+```bash
+python exercises/auto_grader/cli.py new reverse_string

--- a/exercises/auto_grader/cli.py
+++ b/exercises/auto_grader/cli.py
@@ -1,0 +1,21 @@
+# exercises/auto_grader/cli.py
+import sys
+from pathlib import Path
+from generator import create_reverse_string
+
+USAGE = "Usage: python cli.py new <exercise-name>"
+
+def main(args):
+    if len(args) < 2:
+        print(USAGE); return
+    cmd = args[0]
+    name = args[1]
+    if cmd == "new":
+        target = Path("exercises/auto_grader/sample_exercises") / name
+        create_reverse_string(target)
+        print(f"Created exercise: {target}")
+    else:
+        print(USAGE)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/exercises/auto_grader/generator.py
+++ b/exercises/auto_grader/generator.py
@@ -1,0 +1,62 @@
+# exercises/auto_grader/generator.py
+import os
+from pathlib import Path
+from textwrap import dedent
+
+PROBLEM_TEMPLATE = dedent("""\
+# {title}
+
+Difficulty: {difficulty}
+
+## Problem
+{description}
+
+## Example
+Input:
+{example_input}
+
+Output:
+{example_output}
+""")
+
+SOLUTION_TEMPLATE = dedent("""\
+# Hidden/reference solution for {title}
+def solve(x: str) -> str:
+    \"\"\"Reference implementation.\"\"\"
+    return x[::-1]
+""")
+
+TEST_TEMPLATE = dedent("""\
+import importlib.util
+from pathlib import Path
+
+def import_solution(path):
+    spec = importlib.util.spec_from_file_location("solution", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+def test_examples():
+    sol = import_solution(Path(__file__).parent / "solution.py")
+    assert sol.solve({example_input!r}) == {example_output!r}
+""")
+
+def create_reverse_string(dirpath):
+    dirpath = Path(dirpath)
+    dirpath.mkdir(parents=True, exist_ok=True)
+
+    (dirpath / "problem.md").write_text(PROBLEM_TEMPLATE.format(
+        title="Reverse a String",
+        difficulty="Beginner",
+        description="Given a string, return the reverse of the string.",
+        example_input="hello",
+        example_output="olleh"
+    ))
+
+    (dirpath / "solution.py").write_text(SOLUTION_TEMPLATE.format(title="Reverse a String"))
+
+    (dirpath / "test_solution.py").write_text(TEST_TEMPLATE.format(example_input="hello", example_output="olleh"))
+
+if __name__ == "__main__":
+    create_reverse_string("exercises/auto_grader/sample_exercises/reverse_string")
+    print("Sample exercise created.")

--- a/exercises/auto_grader/grader.py
+++ b/exercises/auto_grader/grader.py
@@ -1,0 +1,19 @@
+# exercises/auto_grader/grader.py
+import subprocess
+import sys
+from pathlib import Path
+
+def run_tests(exercise_path: Path):
+    print(f"Running pytest in {exercise_path}")
+    cmd = [sys.executable, "-m", "pytest", "-q", str(exercise_path)]
+    proc = subprocess.run(cmd)
+    return proc.returncode
+
+if __name__ == "__main__":
+    path = Path("exercises/auto_grader/sample_exercises/reverse_string")
+    rc = run_tests(path)
+    if rc == 0:
+        print("All tests passed ✅")
+    else:
+        print("Some tests failed ❌")
+    sys.exit(rc)

--- a/exercises/auto_grader/sample_exercises/reverse_string/solution.py
+++ b/exercises/auto_grader/sample_exercises/reverse_string/solution.py
@@ -1,0 +1,4 @@
+# Hidden/reference solution (for maintainers)
+def solve(x: str) -> str:
+    """Return reversed string."""
+    return x[::-1]

--- a/exercises/auto_grader/sample_exercises/reverse_string/test_solution.py
+++ b/exercises/auto_grader/sample_exercises/reverse_string/test_solution.py
@@ -1,0 +1,12 @@
+import importlib.util
+from pathlib import Path
+
+def import_solution(path):
+    spec = importlib.util.spec_from_file_location("solution", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+def test_examples():
+    sol = import_solution(Path(__file__).parent / "solution.py")
+    assert sol.solve("hello") == "olleh"


### PR DESCRIPTION
## Summary
Adds an adaptive exercise generator and auto-grader that scaffolds exercises and provides pytest tests. Includes a sample 'reverse_string' exercise.

## Files added
- exercises/auto_grader/generator.py
- exercises/auto_grader/grader.py
- exercises/auto_grader/cli.py
- exercises/auto_grader/README.md
- exercises/auto_grader/sample_exercises/reverse_string/*

## How to test locally
1. python -m pip install -U pytest
2. python exercises/auto_grader/cli.py new reverse_string   # optional
3. python exercises/auto_grader/grader.py

## PR checklist
- [ ] problem.md is clear and beginner-friendly
- [ ] test_solution.py exists and is deterministic
- [ ] solution.py is included only if intended (or hidden in separate branch)
- [ ] README updated with instructions
- [ ] Ran pytest locally and tests pass
- [ ] Added commit message as requested

## Notes for maintainers
- Consider hiding `solution.py` from learners by storing reference solutions in a `solutions/` branch or using a `.hidden` suffix.
- Remove `|| true` from CI when ready to block failing tests.

